### PR TITLE
Removes references to external speckle resources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,10 +19,6 @@
     <strong>
       We're sorry but speckle doesn't work properly without JavaScript enabled. Please enable it to continue.
     </strong>
-    <br>
-    Sorry to add so much crap to the interwebs, but we're doing our best, and prioritised dev velocity over being elegant. We're an open source project, afterall - so if you want to help us out check out https://speckle.works.
-    <br>
-    xxx
   </noscript>
   <div id="app"></div>
   <!-- built files will be auto injected -->

--- a/speckle-plugin-manifest.json
+++ b/speckle-plugin-manifest.json
@@ -4,8 +4,8 @@
   "desc": "YEAH! Speckle has a frontend yo!",
   "serveFrom": "/",
   "serveSource": "/dist",
-  "author": "Speckle Project Contributors",
-  "contact":"hello@speckle.works",
-  "homepage":"https://speckle.works",
-  "git":"https://github.com/speckleworks/SpeckleAdmin"
+  "author": "Speckle Project Community",
+  "contact":"david.dekoning@arup.com",
+  "homepage":"https://speckle.arup.com",
+  "git":"https://github.com/arup-group/SpeckleAdmin"
 }

--- a/src/components/ClientGraph.vue
+++ b/src/components/ClientGraph.vue
@@ -4,7 +4,7 @@
       <div align="center">
       <v-icon small left>import_export</v-icon>&nbsp;
       <b>SpeckleViz&trade;</b>&nbsp;
-      <v-btn class="ml-6" round href="https://speckle.systems/docs/web/speckleviz/" target="_blank">
+      <v-btn class="ml-6" round href="https://docs.speckle.arup.com/plugins/web.html" target="_blank">
         <v-icon left>help_outline</v-icon>
         need help? read the docs
         <v-icon right>arrow_right_alt</v-icon>

--- a/src/components/NavDrawer.vue
+++ b/src/components/NavDrawer.vue
@@ -140,7 +140,7 @@
       <v-divider class='ma-3'></v-divider>
     </v-list>
     <v-list xxxv-if='$store.state.isAuth' two-line subheader>
-      <v-list-tile href='https://speckle.systems/docs/web/management' target='_blank'>
+      <v-list-tile href='https://docs.speckle.arup.com/plugins/web.html' target='_blank'>
         <v-list-tile-action>
           <v-icon>help</v-icon>
         </v-list-tile-action>
@@ -149,7 +149,7 @@
           <v-list-tile-sub-title class='caption'>Help for this web app.</v-list-tile-sub-title>
         </v-list-tile-content>
       </v-list-tile>
-      <v-list-tile href='https://speckle.systems/docs/essentials/start' target='_blank'>
+      <v-list-tile href='https://docs.speckle.arup.com/getting-started.html' target='_blank'>
         <v-list-tile-action>
           <v-icon>help_outline</v-icon>
         </v-list-tile-action>
@@ -175,7 +175,7 @@
       <v-card-text>
         <div class='text-uppercase text-xs-center-xxx caption ml-0 pa-5 ml-2 mt-3 mb-3'>
           Brought to you by:<br>
-          <a href='https://speckle.arup.com/' target="_blank" style="xxxcolor:white; text-decoration: none;"><b>Speckle Community Extensions</b>,
+          <a href='https://docs.speckle.arup.com/' target="_blank" style="xxxcolor:white; text-decoration: none;"><b>Speckle Community Extensions</b>,
             <span class=' caption'>the open source data platform for AEC.</span></a>
           <!-- <v-divider class='my-4'></v-divider> -->
         </div>

--- a/src/components/NavDrawer.vue
+++ b/src/components/NavDrawer.vue
@@ -175,7 +175,7 @@
       <v-card-text>
         <div class='text-uppercase text-xs-center-xxx caption ml-0 pa-5 ml-2 mt-3 mb-3'>
           Brought to you by:<br>
-          <a href='https://speckle.works' target="_blank" style="xxxcolor:white; text-decoration: none;"><b>Speckle</b>,
+          <a href='https://speckle.arup.com/' target="_blank" style="xxxcolor:white; text-decoration: none;"><b>Speckle Community Extensions</b>,
             <span class=' caption'>the open source data platform for AEC.</span></a>
           <!-- <v-divider class='my-4'></v-divider> -->
         </div>

--- a/src/main.js
+++ b/src/main.js
@@ -177,16 +177,10 @@ let initApp = ( ) => {
     render: h => h( App ),
     created( ) {
       try {
-        if ( Store.state.serverManifest != null )
-          if ( Store.state.serverManifest.telemetry === 'true' ) {
-            Vue.use( VueCountly, Countly, {
-              app_key: '04ac5c1e31e993f2624e964475dd949e9a3443f5',
-              url: 'https://telemetry.speckle.works',
-            } );
+        if ( Store.state.serverManifest != null ) {
+          // put init code here
+        }
 
-            this.$Countly.q.push( [ 'track_sessions' ] )
-            Router.$Countly = this.$Countly
-          }
       } catch ( error ) {
         // eslint-disable-next-line no-console
         console.error( error )

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -7,22 +7,21 @@
       </v-flex>
       <v-flex xs12 py-5 class='' v-if='streams.length === 0 && projects.length === 0'>
         <div class='headline font-weight-light mb-4'>
-          👋 Hello {{$store.state.user.name}}! It looks like it's your first time here. Don't forget to check out the <a href='https://speckle.systems/docs/essentials/start' target='_blank'>guide</a>!
+          👋 Hello {{$store.state.user.name}}! It looks like it's your first time here. Don't forget to check out the <a href='https://docs.speckle.arup.com' target='_blank'>Speckle website</a>!
         </div>
         <v-divider></v-divider>
         <div class='mt-4 subheading'>
-          You can also get in touch with the rest of the speckle community via:
+          You can also get in touch with the Speckle@Arup community via:
           <ul>
-            <li><a href='https://discourse.speckle.works' target="_blank">Discourse</a></li>
-            <li><a href='https://slacker.speckle.works' target="_blank">Slack</a></li>
-            <li><a href='https://twitter.com/SpeckleSystems' target="_blank">Twitter</a></li>
+            <li><a href='https://teams.microsoft.com/l/team/19%3a4d7846f52ebb4759b0fd3c53d9e09c45%40thread.skype/conversations?groupId=672fa522-1971-4209-8c5f-22c927093b8a&tenantId=4ae48b41-0137-4599-8661-fc641fe77bea'
+             target="_blank">Teams</a></li>
           </ul>
         </div>
       </v-flex>
       <v-flex xs12 v-if='streams.length !== 0 || projects.length !== 0'>
         <search-everything />
       </v-flex>
-      <v-flex xs12 md6 lg4 v-if='streams.length !== 0 || projects.length !== 0'>
+      <v-flex xs12 md6 lg6 v-if='streams.length !== 0 || projects.length !== 0'>
         <v-card class="elevation-1">
           <v-card-title>
             <v-icon left>
@@ -55,7 +54,7 @@
           </v-card-actions>
         </v-card>
       </v-flex>
-      <v-flex xs12 md6 lg4 v-if='streams.length !== 0 || projects.length !== 0'>
+      <v-flex xs12 md6 lg6 v-if='streams.length !== 0 || projects.length !== 0'>
         <v-card class="elevation-1">
           <v-card-title>
             <v-icon left>
@@ -87,34 +86,16 @@
           </v-card-actions>
         </v-card>
       </v-flex>
-      <v-flex xs12 md6 lg4>
-        <v-toolbar dense class=' '>
-          <v-icon left>
-            fiber_new
-          </v-icon>
-          <span class='title font-weight-light'>
-            Speckle News
-          </span>
-          <v-spacer></v-spacer>
-          <!-- <v-toolbar-items>
-            <v-btn flat href='https://twitter.com/SpeckleSystems' target='_blank'>Follow Speckle!</v-btn>
-          </v-toolbar-items> -->
-        </v-toolbar>
-        <v-card style='max-height: 560px; overflow-y: auto;'>
-          <Timeline :id="'specklesystems'" :sourceType="'profile'" :options="{ theme: $store.state.dark ? 'dark' : '', tweetLimit: 10 }" />
-        </v-card>
-        <v-btn block large xxxcolor='black' href='https://twitter.com/SpeckleSystems' target='_blank'>Follow Speckle For More!</v-btn>
-      </v-flex>
+
     </v-layout>
   </v-container>
 </template>
 <script>
-import { Timeline } from 'vue-tweet-embed'
 import SearchEverything from '@/components/SearchEverything.vue'
 
 export default {
   name: 'HomeView',
-  components: { SearchEverything, Timeline },
+  components: { SearchEverything },
   computed: {
     latestStreams( ) {
       return this.streams.slice( 0, 7 )

--- a/src/views/Projects.vue
+++ b/src/views/Projects.vue
@@ -21,7 +21,7 @@
       <!-- Empty state handler -->
       <v-flex xs12 v-if='projects.length === 0'>
         <p class='title font-weight-light'>
-          👋 Hello {{$store.state.user.name}}! It looks like you haven't created any projects yet. Don't forget to check out the <a href='https://speckle.systems/docs/web/management' target='_blank'>guide</a>!
+          👋 Hello {{$store.state.user.name}}! It looks like you haven't created any projects yet. Don't forget to check out the <a href='https://docs.speckle.arup.com/plugins/web.html' target='_blank'>guide</a>!
         </p>
       </v-flex>
       <v-flex xs12>

--- a/src/views/SigninCallback.vue
+++ b/src/views/SigninCallback.vue
@@ -12,7 +12,7 @@
           <v-card-text v-else class='pt-4'>
             <p class='headline font-weight-light'><v-icon class='pb-1'>error</v-icon>&nbsp;Oups. Something bad happened :(</p>
             <p class='caption' v-if='sslProblem'>
-              Your server is not using SSL (i.e, your server url is http and not http<b>s</b>. Please check the community supported <a href='https://discourse.speckle.works/t/speckle-server-debian-9-installation-notes-for-development-machines/344' target="_blank"> server deployment instructions</a>. If still in trouble, don't hesitate to get in touch on <a href="https://speckle-works.slack.com/join/shared_invite/enQtNjY5Mzk2NTYxNTA4LTU4MWI5ZjdhMjFmMTIxZDIzOTAzMzRmMTZhY2QxMmM1ZjVmNzJmZGMzMDVlZmJjYWQxYWU0MWJkYmY3N2JjNGI">slack</a> or <a href="https://discourse.speckle.works/">discourse</a>.</p>
+              Your server is not using SSL (i.e, your server url is http and not http<b>s</b>.</p>
             <v-btn block to='/signin'>back to signin</v-btn>
           </v-card-text>
           <v-card-actions>

--- a/src/views/Streams.vue
+++ b/src/views/Streams.vue
@@ -23,7 +23,7 @@
       <!-- Empty state handler -->
       <v-flex xs12 v-if='streams.length === 0'>
         <p class='title font-weight-light'>
-          👋 Hello {{$store.state.user.name}}! It looks like you haven't created any streams yet. Don't forget to check out the <a href='https://speckle.systems/docs/essentials/start' target='_blank'>guide</a>!
+          👋 Hello {{$store.state.user.name}}! It looks like you haven't created any streams yet. Don't forget to check out the <a href='https://docs.speckle.arup.com/getting-started.html' target='_blank'>guide</a>!
         </p>
       </v-flex>
       <v-flex xs12>


### PR DESCRIPTION
This PR changes any urls in the webapp to point to the speckle.arup.com documentation, and removes the twitter feed from the dashboard.