### PR TITLE
[SPEC-269] Add analytics to speckle admin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12124,6 +12124,11 @@
         }
       }
     },
+    "vue-matomo": {
+      "version": "3.14.0-0",
+      "resolved": "https://registry.npmjs.org/vue-matomo/-/vue-matomo-3.14.0-0.tgz",
+      "integrity": "sha512-i1IkZGSXNY84zg1gVU8TOuaqajYDWQYl4Vs7M1mEb21cNhlMZKUxxgElvj+xmv7ytYUc/6ekZbxIS+y6W4qTMQ=="
+    },
     "vue-router": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "msal": "^1.1.1",
     "register-service-worker": "^1.5.2",
     "vue": "^2.6.10",
+    "vue-matomo": "^3.14.0-0",
     "vue-router": "^3.0.1",
     "vuex": "^3.0.1"
   },

--- a/src/integrations/matomo.js
+++ b/src/integrations/matomo.js
@@ -1,0 +1,52 @@
+import Vue from 'vue'
+import VueMatomo from 'vue-matomo'
+import Store from '../store/store'
+
+export function initialiseMatomo (router) {
+  const crypto = window.crypto
+  const email = Store.state.user.email
+  const userId = email ? crypto.subtle.digest('SHA256', email) : 'anon'
+  if(email && email.includes('arup.com')) {
+    Vue.use(VueMatomo, {
+      // Configure your matomo server and site by providing
+      host: 'https://arupdt.matomo.cloud',
+      siteId: 1,
+  
+      // Enables automatically registering pageviews on the router
+      router: router,
+  
+      // Enables link tracking on regular links. Note that this won't
+      // work for routing links (ie. internal Vue router links)
+      // Default: true
+      enableLinkTracking: false,
+  
+      // Require consent before sending tracking information to matomo
+      // Default: false
+      requireConsent: false,
+  
+      // Whether to track the initial page view
+      // Default: true
+      trackInitialView: true,
+  
+      // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
+      // Default: false
+      enableHeartBeatTimer: true,
+  
+      // Set the heartbeat timer interval
+      // Default: 15
+      heartBeatTimerInterval: 60,
+  
+      // UserID passed to Matomo (see https://developer.matomo.org/guides/tracking-javascript-guide#user-id)
+      // Default: undefined
+      userId: userId,
+  
+      // Share the tracking cookie across subdomains (see https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains)
+      // Default: undefined, example '*.example.com'
+      cookieDomain: '*.speckle.arup.com',
+  
+      // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
+      // Default: undefined, example: '*.example.com'
+      domains: '*.speckle.arup.com'
+    })
+  }
+}

--- a/src/integrations/matomo.js
+++ b/src/integrations/matomo.js
@@ -1,52 +1,51 @@
 import Vue from 'vue'
 import VueMatomo from 'vue-matomo'
-import Store from '../store/store'
 
 export function initialiseMatomo (router) {
-  const crypto = window.crypto
-  const email = Store.state.user.email
-  const userId = email ? crypto.subtle.digest('SHA256', email) : 'anon'
-  if(email && email.includes('arup.com')) {
-    Vue.use(VueMatomo, {
-      // Configure your matomo server and site by providing
-      host: 'https://arupdt.matomo.cloud',
-      siteId: 1,
-  
-      // Enables automatically registering pageviews on the router
-      router: router,
-  
-      // Enables link tracking on regular links. Note that this won't
-      // work for routing links (ie. internal Vue router links)
-      // Default: true
-      enableLinkTracking: false,
-  
-      // Require consent before sending tracking information to matomo
-      // Default: false
-      requireConsent: false,
-  
-      // Whether to track the initial page view
-      // Default: true
-      trackInitialView: true,
-  
-      // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
-      // Default: false
-      enableHeartBeatTimer: true,
-  
-      // Set the heartbeat timer interval
-      // Default: 15
-      heartBeatTimerInterval: 60,
-  
-      // UserID passed to Matomo (see https://developer.matomo.org/guides/tracking-javascript-guide#user-id)
-      // Default: undefined
-      userId: userId,
-  
-      // Share the tracking cookie across subdomains (see https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains)
-      // Default: undefined, example '*.example.com'
-      cookieDomain: '*.speckle.arup.com',
-  
-      // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
-      // Default: undefined, example: '*.example.com'
-      domains: '*.speckle.arup.com'
-    })
+  if(window.location.origin.includes('localhost')) return
+  const emailHash = window.localStorage.getItem('emailHash')
+  const config = matomoConfig(router)
+  if (emailHash) Object.assign(config, {userId: emailHash})
+  Vue.use(VueMatomo, config)
+}
+
+function matomoConfig (router) {
+  return {
+    // Configure your matomo server and site by providing
+    host: 'https://arupdt.matomo.cloud',
+    siteId: 1,
+
+    // Enables automatically registering pageviews on the router
+    router: router,
+
+    // Enables link tracking on regular links. Note that this won't
+    // work for routing links (ie. internal Vue router links)
+    // Default: true
+    enableLinkTracking: false,
+
+    // Require consent before sending tracking information to matomo
+    // Default: false
+    requireConsent: false,
+
+    // Whether to track the initial page view
+    // Default: true
+    trackInitialView: true,
+
+    // Enable the heartbeat timer (https://developer.matomo.org/guides/tracking-javascript-guide#accurately-measure-the-time-spent-on-each-page)
+    // Default: false
+    enableHeartBeatTimer: true,
+
+    // Set the heartbeat timer interval
+    // Default: 15
+    heartBeatTimerInterval: 60,
+
+    // Share the tracking cookie across subdomains (see https://developer.matomo.org/guides/tracking-javascript-guide#measuring-domains-andor-sub-domains)
+    // Default: undefined, example '*.example.com'
+    cookieDomain: '*.speckle.arup.com',
+
+    // Tell Matomo the website domain so that clicks on these domains are not tracked as 'Outlinks'
+    // Default: undefined, example: '*.example.com'
+    domains: '*.speckle.arup.com'
   }
+  
 }

--- a/src/integrations/matomo.js
+++ b/src/integrations/matomo.js
@@ -2,7 +2,7 @@ import Vue from 'vue'
 import VueMatomo from 'vue-matomo'
 
 export function initialiseMatomo (router) {
-  if(window.location.origin.includes('localhost')) return
+  if(!process.env.VUE_APP_MATOMO_URL) return
   const emailHash = window.localStorage.getItem('emailHash')
   const config = matomoConfig(router)
   if (emailHash) Object.assign(config, {userId: emailHash})
@@ -11,8 +11,8 @@ export function initialiseMatomo (router) {
 
 function matomoConfig (router) {
   return {
-    // Configure your matomo server and site by providing
-    host: process.env.VUE_APP_MATOMO_URL,
+    // Configure host and site using build configuration
+    host: process.env.VUE_APP_MATOMO_URL.replace('/matomo.php', ''),
     siteId: process.env.VUE_APP_MATOMO_SITE,
 
     // Enables automatically registering pageviews on the router

--- a/src/integrations/matomo.js
+++ b/src/integrations/matomo.js
@@ -12,8 +12,8 @@ export function initialiseMatomo (router) {
 function matomoConfig (router) {
   return {
     // Configure your matomo server and site by providing
-    host: 'https://arupdt.matomo.cloud',
-    siteId: 1,
+    host: process.env.VUE_APP_MATOMO_URL,
+    siteId: process.env.VUE_APP_MATOMO_SITE,
 
     // Enables automatically registering pageviews on the router
     router: router,

--- a/src/main.js
+++ b/src/main.js
@@ -118,8 +118,7 @@ Vue.mixin( {
 import EditableSpan from './components/EditableSpan.vue'
 Vue.component( 'editable-span', EditableSpan )
 
-import Countly from 'countly-sdk-web'
-import VueCountly from 'vue-countly'
+import { initialiseMatomo } from './integrations/matomo'
 
 // Automatic 'plugin' component registration:
 // H/T to Chris Fritz...
@@ -177,20 +176,14 @@ let initApp = ( ) => {
     render: h => h( App ),
     created( ) {
       try {
-        if ( Store.state.serverManifest != null )
-          if ( Store.state.serverManifest.telemetry === 'true' ) {
-            Vue.use( VueCountly, Countly, {
-              app_key: '04ac5c1e31e993f2624e964475dd949e9a3443f5',
-              url: 'https://telemetry.speckle.works',
-            } );
-
-            this.$Countly.q.push( [ 'track_sessions' ] )
-            Router.$Countly = this.$Countly
-          }
+        if ( Store.state.serverManifest != null ){
+          initialiseMatomo(Router)
+        }
       } catch ( error ) {
         // eslint-disable-next-line no-console
         console.error( error )
       }
     }
   } ).$mount( '#app' )
+  
 }

--- a/src/main.js
+++ b/src/main.js
@@ -176,9 +176,7 @@ let initApp = ( ) => {
     render: h => h( App ),
     created( ) {
       try {
-        if ( Store.state.serverManifest != null ){
-          initialiseMatomo(Router)
-        }
+        initialiseMatomo(Router)
       } catch ( error ) {
         // eslint-disable-next-line no-console
         console.error( error )

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1114,7 +1114,21 @@ export default new Vuex.Store( {
         defaultServers.forEach( s => usedServers.add( `${s}/api` ) )
         localStorage.setItem( 'allSpeckleServers', [ ...usedServers ] )
 
-        return resolve( )
+        const crypto = window.crypto
+        const email = userProfile.data.resource.email
+        if(email.includes('@arup.com')) {
+          crypto.subtle
+                .digest('SHA-256', new TextEncoder().encode(email))
+                .then(userId => {
+                  const hashArray = Array.from(new Uint8Array(userId));     
+                  const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join(''); 
+                  if(window._paq) window._paq.push(['setUserId', hashHex]);
+                  localStorage.setItem('emailHash', hashHex)
+                  resolve( )
+          })
+        } else {
+          resolve( )
+        }
       } catch ( err ) {
         console.log( err )
         return reject( err.message )

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1115,7 +1115,7 @@ export default new Vuex.Store( {
         localStorage.setItem( 'allSpeckleServers', [ ...usedServers ] )
 
         const crypto = window.crypto
-        const email = userProfile.data.resource.email
+        const email = userProfile.data.resource.email.trim().toLowerCase()
         if(email.includes('@arup.com')) {
           crypto.subtle
                 .digest('SHA-256', new TextEncoder().encode(email))

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1116,13 +1116,13 @@ export default new Vuex.Store( {
 
         const crypto = window.crypto
         const email = userProfile.data.resource.email.trim().toLowerCase()
-        if(email.includes('@arup.com')) {
+        if(window._paq && email.includes('@arup.com')) {
           crypto.subtle
                 .digest('SHA-256', new TextEncoder().encode(email))
                 .then(userId => {
                   const hashArray = Array.from(new Uint8Array(userId));     
                   const hashHex = hashArray.map(b => b.toString(16).padStart(2, '0')).join(''); 
-                  if(window._paq) window._paq.push(['setUserId', hashHex]);
+                  window._paq.push(['setUserId', hashHex]);
                   localStorage.setItem('emailHash', hashHex)
                   resolve( )
           })


### PR DESCRIPTION
Add analytics to Speckle Admin. 

Hash the email address to use for the userID to track user across different sites.